### PR TITLE
Changes for ghc 7.5

### DIFF
--- a/System/Console/Terminfo/PrettyPrint/Curses.hs
+++ b/System/Console/Terminfo/PrettyPrint/Curses.hs
@@ -7,7 +7,7 @@ module System.Console.Terminfo.PrettyPrint.Curses
 
 import Data.Functor
 import Foreign.Marshal.Error (throwIfNull)
-import Foreign.C.Types (CInt)
+import Foreign.C.Types (CInt(..))
 import Foreign.Ptr (Ptr)
 import Foreign.Storable (peek)
 

--- a/wl-pprint-terminfo.cabal
+++ b/wl-pprint-terminfo.cabal
@@ -40,7 +40,7 @@ library
     semigroups       >= 0.8.3.1 && < 0.9,
     containers       >= 0.4     && < 0.6,
     wl-pprint-extras >= 1.6.3.1 && < 1.7,
-    bytestring       >= 0.9.1   && < 0.10,
+    bytestring       >= 0.9.1   && < 0.11,
     terminfo         >= 0.3.2   && < 0.4,
     transformers     >= 0.2     && < 0.4
 


### PR DESCRIPTION
Fixes ghc 7.5 compiler error:

[1 of 2] Compiling System.Console.Terminfo.PrettyPrint.Curses ( System/Console/Terminfo/PrettyPrint/Curses.hs, dist/build/System/Console/Terminfo/PrettyPrint/Curses.o )

System/Console/Terminfo/PrettyPrint/Curses.hs:25:1:
    Unacceptable result type in foreign declaration: IO CInt
    When checking declaration:
      foreign import ccall unsafe "static cursed.h endwin" endWin
        :: IO CInt

Compiled with ghc 7.4.2 and 7.5.20120621
