### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/wl-pprint-terminfo.cabal
+++ b/wl-pprint-terminfo.cabal
@@ -1,7 +1,7 @@
 name:               wl-pprint-terminfo
 category:           Control, Monads, Text
 version:            3.7.1.4
-cabal-version:      >= 1.6
+cabal-version:      >= 1.8
 license:            BSD3
 license-file:       LICENSE
 author:             Edward A. Kmett


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: wl-pprint-terminfo.cabal:50:35: version operators used. To use                                                                                                                                                                                                            
version operators the package needs to specify at least 'cabal-version: >=                                                                                                                                                                                                         
1.8'.  
...
```